### PR TITLE
Add .travis.yml for automatic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+sudo: false
+dist: trusty
+before_install: sudo apt-get install --assume-yes gcc-arm-none-eabi
+script: make


### PR DESCRIPTION
`.travis.yml` is the configuration file for Travis CI. After this pull request is merged, Travis CI can be used for testing the compilation of the PROS branch.